### PR TITLE
Add tests verifying Minikube setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,13 @@ before_script:
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 script:
+- kubectl cluster-info
+# Verify kube-addon-manager.
+# kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
+- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
+# Wait for kube-dns to be ready.
+- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 # Create example Redis deployment on Kubernetes.
-- kubectl cluster-info 
-- kubectl run travis-example --image=redis
-- kubectl get deployment
+- kubectl run travis-example --image=redis --labels="app=travis-example"
+# Make sure created pod is scheduled and running.
+- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n default get pods -lapp=travis-example -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for travis-example deployment to be available"; kubectl get pods -n default; done


### PR DESCRIPTION
This PR adds tests for verifying is Minikube setup fully-available and working.

The following tests are added:
* `kube-addon-manager` is Running. `kube-addon-manager` is handling all additional components, e.g. kube-dns, but also some others, so we want to be sure it's running.
* `kube-dns` is Running (from https://github.com/coreos/prometheus-operator/blob/cad1cb29a35b964258367090a837363be73afbdb/scripts/create-minikube.sh#L39-L40).
* Is example Redis pod running. This way we're sure scheduling works and the pod is up and running.

Additional tests case can be added as well. If you have ideas, let me know. I'll try to think of some more tests.

I also thought about checking is `/healthz` endpoint returning status code 200 (as mentioned in #9), but it seems [Minikube doesn't have `/healthz` endpoint enabled by default](https://github.com/kubernetes/minikube/blob/dcb5c2cc5077d9963ce96833490cce73bd225feb/pkg/localkube/proxy.go#L67), so I decided to leave it aside for now.

I'll create another PR for adding this tests cases to the master branch.

Closes #9.