### PR TITLE
Update RBAC note to include information how to enable RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # travis-minikube
 
-Quick example of running [minikube](https://github.com/kubernetes/minikube) on [Travis CI](https://travis-ci.org/) with [Kubernetes](https://github.com/kubernetes/kubernetes) version `1.9.0`. Note that [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) will be enabled in this cluster by default.
+Quick example of running [minikube](https://github.com/kubernetes/minikube) on [Travis CI](https://travis-ci.org/) with [Kubernetes](https://github.com/kubernetes/kubernetes) version `1.9.0`.
 To read more in detail check out my [guest blog post](https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube) on the Travis CI blog.
-
 
 To switch Kubernetes cluster versions just replace the `1.9.0` version in the `.travis.yml` file.
 
 For `1.10.0` Kubernetes example see the [minikube-26-kube-1.10](https://github.com/LiliC/travis-minikube/tree/minikube-26-kube-1.10) branch.
+
+Note that [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) is not enabled on this cluster by default. To enable RBAC, you need to start Minikube with the `--extra-config=apiserver.Authorization.Mode=RBAC` flag.
+Starting Minikube with RBAC enabled requires the appropriate RBAC roles to be created in the `kube-system` namespace, so all components work as expected. One of the possible solutions is to give the `default` ServiceAccount in the `kube-system` namespace the `cluster-admin` permissions. For more details see the [issue #1722](https://github.com/kubernetes/minikube/issues/1722).


### PR DESCRIPTION
:wave:

I've experimented with Travis and Minikube quite a bit and found out that RBAC is not enabled by default (even when running 1.9 and 1.10), so I decided to create a PR to update the README file.

RBAC can be enabled by starting Minikube with the `--extra-config=apiserver.Authorization.Mode=RBAC` flag. However, this brings up several problems with other components due to missing RBAC permissions.

There're several solutions to this problem. More details can be found in https://github.com/kubernetes/minikube/issues/1722. Probably the most easiest, but not the most secure one is to give `cluster-admin` permissions to the `default` ServiceAccount in the `kube-system` namespace.

Here's a little snippet for verifying this. This manifest creates Role and RoleBinding to allow the `sa` ServiceAccount to list and get Secrets.
```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: role-test
rules:
- apiGroups: [""]
  resources: ["secrets"]
  verbs: ["get", "list"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: rolebinding-test
subjects:
- kind: ServiceAccount
  name: sa
roleRef:
  kind: Role
  name: role-test
  apiGroup: rbac.authorization.k8s.io
```
Now, tell `kubectl` about the `sa` ServiceAccount:
```
kubectl config set-credentials sa --token=$(kubectl get secret <secret_name> -o jsonpath={.data.token} | base64 -d)
```

Listing Secrets should work as expected:
```
kubectl --user=sa get secrets
```
Trying to create a Secret should result in an error:
```
kubectl --user=sa create secret generic test
```
```
Error from server (Forbidden): secrets is forbidden: User "system:serviceaccount:test:sa" cannot create secrets in the namespace "default": no RBAC policy matched
```
However, in Minikube cluster started without RBAC flag it works:
```
secret/test created
```

I was not sure is this PR needed and how to fix this, so if you have any other idea, let me know. Another solution could be to add the flag to the `.travis.yml` as well.

Relevant to https://github.com/kubernetes/minikube/issues/1722