### PR TITLE
Use the kubeadmin for minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+# We need the systemd for the kubeadm and it's default from 16.04+
+dist: xenial
 # This moves Kubernetes specific config files.
 env:
 - CHANGE_MINIKUBE_NONE_USER=true
@@ -10,8 +12,8 @@ before_script:
 # Download kubectl, which is a requirement for using minikube.
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.10.0
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.28.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+- sudo minikube start --vm-driver=none --bootstrapper=kubeadm --kubernetes-version=v1.10.0
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.


### PR DESCRIPTION
- Since the kubeadm is relay on `systemd`, we should use the `ubuntu 16.04` as the OS.
- Fix the version of the minikube to 0.28.1
- Change the bootstrapper from `localkube` to `kubeadm`